### PR TITLE
Fixed missing `"GLFW_INCLUDE_NONE"` in linux build

### DIFF
--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
@@ -1,4 +1,3 @@
-#include <glad/glad.h>
 #include "hzpch.h"
 #include "ImGuiLayer.h"
 
@@ -10,6 +9,7 @@
 
 // TEMPORARY
 #include <GLFW/glfw3.h>
+#include <glad/glad.h>
 
 namespace Hazel {
 

--- a/Hazel/src/Platform/OpenGL/OpenGLContext.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLContext.cpp
@@ -1,8 +1,8 @@
 #include "hzpch.h"
 #include "OpenGLContext.h"
 
-#include <glad/glad.h>
 #include <GLFW/glfw3.h>
+#include <glad/glad.h>
 
 namespace Hazel {
 

--- a/Hazel/src/Platform/Windows/WindowsWindow.h
+++ b/Hazel/src/Platform/Windows/WindowsWindow.h
@@ -3,7 +3,6 @@
 #include "Hazel/Window.h"
 #include "Hazel/Renderer/GraphicsContext.h"
 
-#include <glad/glad.h> // required in WindowsWindow.cpp; but must be included before GLFW
 #include <GLFW/glfw3.h>
 
 namespace Hazel {

--- a/premake5.lua
+++ b/premake5.lua
@@ -22,7 +22,6 @@ group "Dependencies"
 	include "Hazel/vendor/GLFW"
 	include "Hazel/vendor/Glad"
 	include "Hazel/vendor/imgui"
-
 group ""
 
 project "Hazel"
@@ -84,7 +83,8 @@ project "Hazel"
 		defines
 		{
 			"HZ_PLATFORM_LINUX",
-			"HZ_BUILD_DLL"
+			"HZ_BUILD_DLL",
+			"GLFW_INCLUDE_NONE"
 		}
 
 	filter "system:windows"


### PR DESCRIPTION
Adding `"GLFW_INCLUDE_NONE"` to premake, this will make sure the include order between glad and GLFW doesn't matter. So this PR is reverting it back in places where we swapped include orders around.

It is compiling & running for me.