### PR TITLE
Linux support v2 (resolve filepath)

### DIFF
--- a/Hazel/src/Hazel/Application.cpp
+++ b/Hazel/src/Hazel/Application.cpp
@@ -117,7 +117,7 @@ namespace Hazel {
 			s_AbsoluteDirectoryPath = ownPath;
 		return;
 
-	#elif def HZ_PLATFORM_LINUX
+	#elif defined(HZ_PLATFORM_LINUX)
 		// absolute pathname to current working directory of calling process
 		char save_pwd[PATH_MAX];
 		getcwd(save_pwd, sizeof(save_pwd));

--- a/Hazel/src/Hazel/Application.cpp
+++ b/Hazel/src/Hazel/Application.cpp
@@ -103,6 +103,24 @@ namespace Hazel {
 
 	#elif def HZ_PLATFORM_LINUX
 		#error Linux abosulute directory path not implemented
+
+	#else
+		#error Unsupported platform!
+	#endif
+	}
+
+	std::string Application::ResolvePath(const std::string& path)
+	{
+		// This will always return an absolute path
+	#ifdef HZ_PLATFORM_WINDOWS
+		std::filesystem::path fsPath(path);
+		if (fsPath.is_absolute())
+			return path;
+		return GetApplicationDirectory() + "\\" + path;
+
+	#elif def HZ_PLATFORM_LINUX
+		#error Linux resolve directory path not implemented
+
 	#else
 		#error Unsupported platform!
 	#endif

--- a/Hazel/src/Hazel/Application.cpp
+++ b/Hazel/src/Hazel/Application.cpp
@@ -97,9 +97,24 @@ namespace Hazel {
 			std::string absOwnPath(absOwnPathW.begin(), absOwnPathW.end());
 		#endif
 
-		// absOwnPath contains for example "C:\..\Sandbox\Sandbox.exe"
+		// absOwnPath could contain \.. in its path, we remove it
+		// example: "C:\subDir\subsubDir\..\Sandbox" => "C:\subDir\Sandbox"
+		size_t foundIndex = absOwnPath.find("\\..");
+		while (foundIndex < absOwnPath.length())
+		{
+			size_t prevIndex = absOwnPath.rfind("\\", foundIndex - 1);
+			absOwnPath.erase(prevIndex, foundIndex - prevIndex + 3);
+
+			// search again
+			foundIndex = absOwnPath.find("\\..");
+		}
+
+		// absOwnPath contains for example "C:\Sandbox\Sandbox.exe"
 		// Remove the Sandbox.exe part from the end
-		return absOwnPath.substr(0, absOwnPath.rfind("\\"));
+		size_t absOwnDirIndex = absOwnPath.rfind("\\");
+		if (absOwnDirIndex < absOwnPath.length())
+			return absOwnPath.substr(0, absOwnDirIndex + 1);
+		return absOwnPath;
 
 	#elif def HZ_PLATFORM_LINUX
 		#error Linux abosulute directory path not implemented
@@ -116,7 +131,7 @@ namespace Hazel {
 		std::filesystem::path fsPath(path);
 		if (fsPath.is_absolute())
 			return path;
-		return GetApplicationDirectory() + "\\" + path;
+		return GetApplicationDirectory() + path;
 
 	#elif def HZ_PLATFORM_LINUX
 		#error Linux resolve directory path not implemented

--- a/Hazel/src/Hazel/Application.h
+++ b/Hazel/src/Hazel/Application.h
@@ -32,6 +32,7 @@ namespace Hazel {
 
 		inline static Application& Get() { return *s_Instance; }
 		inline static const std::string& GetApplicationDirectory() { return s_AbsoluteDirectoryPath; }
+		static std::string ResolvePath(const std::string& path);
 	private:
 		bool OnWindowClose(WindowCloseEvent& e);
 

--- a/Hazel/src/Hazel/Application.h
+++ b/Hazel/src/Hazel/Application.h
@@ -31,12 +31,12 @@ namespace Hazel {
 		inline Window& GetWindow() { return *m_Window; }
 
 		inline static Application& Get() { return *s_Instance; }
-		inline static const std::string& GetApplicationDirectory() { return s_AbsoluteDirectoryPath; }
+
+		static void CreateAbsoluteDirectoryPath(const char* argv0);
+		inline static const std::string& GetApplicationDirectoryPath() { return s_AbsoluteDirectoryPath; }
 		static std::string ResolvePath(const std::string& path);
 	private:
 		bool OnWindowClose(WindowCloseEvent& e);
-
-		static std::string CreateAbsoluteDirectoryPath();
 	private:
 		std::unique_ptr<Window> m_Window;
 		ImGuiLayer* m_ImGuiLayer;

--- a/Hazel/src/Hazel/Application.h
+++ b/Hazel/src/Hazel/Application.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "Core.h"
 
 #include "Window.h"
@@ -29,8 +31,11 @@ namespace Hazel {
 		inline Window& GetWindow() { return *m_Window; }
 
 		inline static Application& Get() { return *s_Instance; }
+		inline static const std::string& GetApplicationDirectory() { return s_AbsoluteDirectoryPath; }
 	private:
 		bool OnWindowClose(WindowCloseEvent& e);
+
+		static std::string CreateAbsoluteDirectoryPath();
 	private:
 		std::unique_ptr<Window> m_Window;
 		ImGuiLayer* m_ImGuiLayer;
@@ -39,6 +44,7 @@ namespace Hazel {
 		float m_LastFrameTime = 0.0f;
 	private:
 		static Application* s_Instance;
+		static std::string s_AbsoluteDirectoryPath;
 	};
 
 	// To be defined in CLIENT

--- a/Hazel/src/Hazel/Application.h
+++ b/Hazel/src/Hazel/Application.h
@@ -32,7 +32,7 @@ namespace Hazel {
 
 		inline static Application& Get() { return *s_Instance; }
 
-		static void CreateAbsoluteDirectoryPath(const char* argv0 const bool useFallback = true);
+		static void CreateAbsoluteDirectoryPath(const char* argv0, const bool useFallback = true);
 		inline static const std::string& GetApplicationDirectoryPath() { return s_AbsoluteDirectoryPath; }
 		static std::string ResolvePath(const std::string& path);
 	private:

--- a/Hazel/src/Hazel/Application.h
+++ b/Hazel/src/Hazel/Application.h
@@ -32,7 +32,7 @@ namespace Hazel {
 
 		inline static Application& Get() { return *s_Instance; }
 
-		static void CreateAbsoluteDirectoryPath(const char* argv0);
+		static void CreateAbsoluteDirectoryPath(const char* argv0 const bool useFallback = true);
 		inline static const std::string& GetApplicationDirectoryPath() { return s_AbsoluteDirectoryPath; }
 		static std::string ResolvePath(const std::string& path);
 	private:

--- a/Hazel/src/Hazel/EntryPoint.h
+++ b/Hazel/src/Hazel/EntryPoint.h
@@ -6,6 +6,8 @@ int main(int argc, char** argv)
 {
 	Hazel::Log::Init();
 	HZ_CORE_WARN("Initialized Log!");
+    Hazel::Application::CreateAbsoluteDirectoryPath(argv[0]);
+
 	int a = 5;
 	HZ_INFO("Hello! Var={0}", a);
 

--- a/Hazel/src/Hazel/Renderer/Texture.cpp
+++ b/Hazel/src/Hazel/Renderer/Texture.cpp
@@ -1,5 +1,5 @@
 #include "hzpch.h"
-#include "Hazel\Application.h"
+#include "Hazel/Application.h"
 
 #include "Texture.h"
 

--- a/Hazel/src/Hazel/Renderer/Texture.cpp
+++ b/Hazel/src/Hazel/Renderer/Texture.cpp
@@ -1,4 +1,6 @@
 #include "hzpch.h"
+#include "Hazel\Application.h"
+
 #include "Texture.h"
 
 #include "Renderer.h"
@@ -11,7 +13,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(path);
+			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(Application::ResolvePath(path));
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/hzpch.h
+++ b/Hazel/src/hzpch.h
@@ -19,6 +19,6 @@
 #ifdef HZ_PLATFORM_WINDOWS
 	#include <Windows.h>
 
-#elif def HZ_PLATFORM_LINUX
+#elif defined(HZ_PLATFORM_LINUX)
 	#include <unistd.h>
 #endif

--- a/Hazel/src/hzpch.h
+++ b/Hazel/src/hzpch.h
@@ -17,4 +17,7 @@
 
 #ifdef HZ_PLATFORM_WINDOWS
 	#include <Windows.h>
+
+#elif def HZ_PLATFORM_LINUX
+	#include <unistd.h>
 #endif

--- a/Hazel/src/hzpch.h
+++ b/Hazel/src/hzpch.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <iostream>
-#include <memory>
 #include <filesystem>
+#include <limits>
+#include <memory>
 #include <utility>
 #include <algorithm>
 #include <functional>

--- a/Hazel/src/hzpch.h
+++ b/Hazel/src/hzpch.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <memory>
+#include <filesystem>
 #include <utility>
 #include <algorithm>
 #include <functional>

--- a/premake5.lua
+++ b/premake5.lua
@@ -165,6 +165,7 @@ project "Sandbox"
 			"dl",
 			"pthread",
 		}
+
 		defines
 		{
 			"HZ_PLATFORM_LINUX"
@@ -180,6 +181,14 @@ project "Sandbox"
 		defines
 		{
 			"HZ_PLATFORM_WINDOWS"
+		}
+
+		postbuildcommands
+		{
+			-- Delete old assets folder and copy the new assets folder, making sure removed assets are also removed in bin
+			"if exist \"%{cfg.buildtarget.directory}assets/\" del \"%{cfg.buildtarget.directory}/assets/\"",
+			-- Copy the new assets folder
+			"{copy} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}/assets/\""
 		}
 
 	filter "configurations:Debug"


### PR DESCRIPTION
For info about the issue: https://github.com/TheCherno/Hazel/pull/82#issuecomment-523330305
## Behaviour
###### Explained by taking windows example:
1. When creating a new application, it will resolve its location in `Application::Application`:
https://github.com/LovelySanta/Hazel/blob/5a69d42dcd50d99945917771aac02bfacee8411e/Hazel/src/Hazel/Application.cpp#L22-L23
https://github.com/LovelySanta/Hazel/blob/5a69d42dcd50d99945917771aac02bfacee8411e/Hazel/src/Hazel/Application.cpp#L81-L102
2. When creating a texture, it will resolve its filepath when calling the abstracted implementation (here OpenGlTextrue2D)
https://github.com/LovelySanta/Hazel/blob/5a69d42dcd50d99945917771aac02bfacee8411e/Hazel/src/Hazel/Renderer/Texture.cpp#L16
https://github.com/LovelySanta/Hazel/blob/5a69d42dcd50d99945917771aac02bfacee8411e/Hazel/src/Hazel/Application.cpp#L112-L119
3. Post build command to copy assets to bin location (relative to the exe as where it is in distrbution)
https://github.com/LovelySanta/Hazel/blob/5a69d42dcd50d99945917771aac02bfacee8411e/premake5.lua#L186-L192

## TODO
###### To do before this can be merged
- [ ] Resolve `Application::CreateAbsoluteDirectoryPath()`
    - [X] Windows
    - [ ] Linux
- [ ] Resolve `Application::ResolvePath(const std::string& path)`
    - [X] Windows
    - [ ] Linux  *This might work cross platform, but needs testing*
- [ ] Post build command to copy assets folder
    - [X] Windows
    - [ ] Linux