### PR TITLE
Linux support v2 (resolve filepath v2)

### DIFF
--- a/Hazel/src/hzpch.h
+++ b/Hazel/src/hzpch.h
@@ -16,4 +16,7 @@
 
 #ifdef HZ_PLATFORM_WINDOWS
 	#include <Windows.h>
+
+#elif def HZ_PLATFORM_LINUX
+	#include <unistd.h>
 #endif

--- a/Hazel/src/hzpch.h
+++ b/Hazel/src/hzpch.h
@@ -17,6 +17,6 @@
 #ifdef HZ_PLATFORM_WINDOWS
 	#include <Windows.h>
 
-#elif def HZ_PLATFORM_LINUX
+#elif defined(HZ_PLATFORM_LINUX)
 	#include <unistd.h>
 #endif

--- a/premake5.lua
+++ b/premake5.lua
@@ -19,6 +19,13 @@ IncludeDir["ImGui"] = "Hazel/vendor/imgui"
 IncludeDir["glm"] = "Hazel/vendor/glm"
 IncludeDir["stb_image"] = "Hazel/vendor/stb_image"
 
+PostbuildCmd = {}
+PostbuildCmd["SandboxAssets"] = {
+	["EchoMessage"] = "{ECHO} Adding assets from \"%{prj.location}assets\".",
+	["DeleteOld"] = "{DELETE} \"%{cfg.buildtarget.directory}assets/\"",
+	["AddNew"] = "{COPY} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}assets/\"",
+}
+
 group "Dependencies"
 	include "Hazel/vendor/GLFW"
 	include "Hazel/vendor/Glad"
@@ -189,10 +196,8 @@ project "Sandbox"
 
 		postbuildcommands
 		{
-            -- Adding assets to build directory
-            "{ECHO} Adding assets from \"%{prj.location}assets\".",
-            --"{DELETE} \"%{cfg.buildtarget.directory}assets/\"",
-            "{COPY} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}assets/\"",
+			PostbuildCmd["SandboxAssets"]["EchoMessage"],
+			PostbuildCmd["SandboxAssets"]["AddNew"]
 		}
 
 	filter "configurations:Release"
@@ -200,12 +205,10 @@ project "Sandbox"
 		runtime "Release"
 		optimize "on"
 
-        postbuildcommands
+		postbuildcommands
 		{
-            -- Adding assets to build directory
-            "{ECHO} Adding assets from \"%{prj.location}assets\".",
-            --"{DELETE} \"%{cfg.buildtarget.directory}assets/\"",
-            "{COPY} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}assets/\"",
+			PostbuildCmd["SandboxAssets"]["EchoMessage"],
+			PostbuildCmd["SandboxAssets"]["AddNew"]
 		}
 
 	filter "configurations:Dist"
@@ -213,10 +216,9 @@ project "Sandbox"
 		runtime "Release"
 		optimize "on"
 
-        postbuildcommands
+		postbuildcommands
 		{
-            -- Adding assets to build directory
-            "{ECHO} Adding assets from \"%{prj.location}assets\".",
-            "{DELETE} \"%{cfg.buildtarget.directory}assets/\"",
-            "{COPY} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}assets/\"",
+			PostbuildCmd["SandboxAssets"]["EchoMessage"],
+			PostbuildCmd["SandboxAssets"]["DeleteOld"],
+			PostbuildCmd["SandboxAssets"]["AddNew"]
 		}

--- a/premake5.lua
+++ b/premake5.lua
@@ -21,9 +21,9 @@ IncludeDir["stb_image"] = "Hazel/vendor/stb_image"
 
 PostbuildCmd = {}
 PostbuildCmd["SandboxAssets"] = {
-	["EchoMessage"] = "{ECHO} Adding assets from \"%{prj.location}assets\".",
-	["DeleteOld"] = "{DELETE} \"%{cfg.buildtarget.directory}assets/\"",
-	["AddNew"] = "{COPY} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}assets/\"",
+	["EchoMessage"] = "{ECHO} Adding assets from \"%{prj.location}/assets\".",
+	["DeleteOld"] = "{DELETE} \"%{cfg.buildtarget.directory}/assets/\"",
+	["AddNew"] = "{COPY} \"%{prj.location}/assets\" \"%{cfg.buildtarget.directory}/assets/\"",
 }
 
 group "Dependencies"

--- a/premake5.lua
+++ b/premake5.lua
@@ -187,12 +187,36 @@ project "Sandbox"
 		runtime "Debug"
 		symbols "on"
 
+		postbuildcommands
+		{
+            -- Adding assets to build directory
+            "{ECHO} Adding assets from \"%{prj.location}assets\".",
+            --"{DELETE} \"%{cfg.buildtarget.directory}assets/\"",
+            "{COPY} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}assets/\"",
+		}
+
 	filter "configurations:Release"
 		defines "HZ_RELEASE"
 		runtime "Release"
 		optimize "on"
 
+        postbuildcommands
+		{
+            -- Adding assets to build directory
+            "{ECHO} Adding assets from \"%{prj.location}assets\".",
+            --"{DELETE} \"%{cfg.buildtarget.directory}assets/\"",
+            "{COPY} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}assets/\"",
+		}
+
 	filter "configurations:Dist"
 		defines "HZ_DIST"
 		runtime "Release"
 		optimize "on"
+
+        postbuildcommands
+		{
+            -- Adding assets to build directory
+            "{ECHO} Adding assets from \"%{prj.location}assets\".",
+            "{DELETE} \"%{cfg.buildtarget.directory}assets/\"",
+            "{COPY} \"%{prj.location}assets\" \"%{cfg.buildtarget.directory}assets/\"",
+		}


### PR DESCRIPTION
New attempt after #13, This resolves #13.

This add postbuildcommands for Sandbox:
- In debug mode & release mode we copy assets to the bin location
- In dist mode we remove the old assets first, to make sure removed assets are also removed from distribution. Then we copy the assets as before.