### PR TITLE
Removal of the YAML code in PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
----
-name: 'Pull Request'
-about: Propose a fix for a (small) issue in Hazel
-
----
-
 #### Describe the issue (if no issue has been made)
 A clear and concise description of what the issue is. Explain the difference between the expected and the current behavior.
 A screenshot or copy of the error could be helpful as well.


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Partial implementation of TheCherno/Hazel#140: YAML code in the PR template shows up inside the creation of a new PR.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Part of #140
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Removing obsolete YAML code as it shouldn't appear inside the PR itself.

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.
None