### PR TITLE
Remove obsolete glwf logging messages init + terminate

### DIFF
--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -41,7 +41,6 @@ namespace Hazel {
 
 		if (s_GLFWWindowCount == 0)
 		{
-			HZ_CORE_INFO("Initializing GLFW");
 			int success = glfwInit();
 			HZ_CORE_ASSERT(success, "Could not intialize GLFW!");
 			glfwSetErrorCallback(GLFWErrorCallback);
@@ -153,7 +152,6 @@ namespace Hazel {
 
 		if (--s_GLFWWindowCount == 0)
 		{
-			HZ_CORE_INFO("Terminating GLFW");
 			glfwTerminate();
 		}
 	}


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Partial implementation of TheCherno/Hazel#140: In TheCherno/Hazel#128 a counter was added to correctly terminate GLFW. With this PR, obsolete logging messages where added. We log when it fails, but it is obsolete to log it to notify the user we're initialising it. This was more usefull just for testing purposes.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Part of TheCherno#140
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Removing the obsolete logging messages to keep the console clean.

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.
None