### PR TITLE
Links aren't applicable on Linux when building a library

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -82,15 +82,6 @@ project "Hazel"
 	filter "system:linux"
 --		pic "on"
 
-		links 
-		{ 
-			"Xrandr",
-			"Xi",
-			"GLU",
-			"GL",
-			"X11"
-		}
-
 		defines
 		{
 			"HZ_PLATFORM_LINUX",


### PR DESCRIPTION
Building static libraries on Linux does not refer to any dependent libraries.
The Links entry can be removed from the Hazel library linux filter.

#### Building static libraries on Linux does not refer to any dependent libraries.
Linux static libraries are made by combining the compiled object files into a library archive.  Building the Hazel library archive doesn't involve using the libraries referred to by the Hazel object files.  The libraries are only required when linking an executable against the Hazel static library.

The Links entry doesn't need to be maintained for the system:linux filter for Hazel.
